### PR TITLE
Improve readability of Settings page

### DIFF
--- a/RainbowTaskbar/Editor/Pages/Settings.xaml
+++ b/RainbowTaskbar/Editor/Pages/Settings.xaml
@@ -1,4 +1,4 @@
-﻿<Page x:Class="RainbowTaskbar.Editor.Pages.Settings"
+<Page x:Class="RainbowTaskbar.Editor.Pages.Settings"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -15,15 +15,18 @@
             </ResourceDictionary.MergedDictionaries>
             <loc:LanguageConverter x:Key="LanguageConverter" />
         </ResourceDictionary>
-        
+
     </Page.Resources>
-    <Grid Margin="16">
+    <Grid Margin="0,25,0,0">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
         </Grid.RowDefinitions>
-        <StackPanel>
-            <TextBlock FontSize="32" FontWeight="SemiBold" Text="{DynamicResource general}"></TextBlock>
+        <StackPanel HorizontalAlignment="Center">
+            <TextBlock FontSize="32" FontWeight="SemiBold" Text="{DynamicResource general}" HorizontalAlignment="Center"></TextBlock>
+            <Grid Height="15"/>
+            <!-- Little Spacer -->
+
             <CheckBox Content="{DynamicResource runstartup}" IsChecked="{Binding SettingsCfg.RunAtStartup}"></CheckBox>
             <CheckBox Content="{DynamicResource checkupdate}" IsChecked="{Binding SettingsCfg.CheckUpdate}"></CheckBox>
             <CheckBox Content="{DynamicResource showicon}" IsChecked="{Binding SettingsCfg.ShowTrayIcon}"></CheckBox>
@@ -38,9 +41,15 @@
                 </ComboBox>
             </StackPanel>
 
-            <TextBlock FontSize="32" FontWeight="SemiBold" Text="{DynamicResource workshop}"></TextBlock>
-            <StackPanel Orientation="Horizontal">
-                <TextBlock FontSize="16" xml:space="preserve" Text="{DynamicResource signedin}"></TextBlock>
+            <Grid Height="50"/>
+            <!-- Big Spacer -->
+
+            <TextBlock FontSize="32" FontWeight="SemiBold" Text="{DynamicResource workshop}" HorizontalAlignment="Center"></TextBlock>
+            <Grid Height="15"/>
+            <!-- Little Spacer -->
+
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                <TextBlock FontSize="16" xml:space="preserve" Text="{DynamicResource signedin}" FontWeight="SemiBold"></TextBlock>
                 <TextBlock FontSize="16" xml:space="preserve" Text=" ("></TextBlock>
                 <TextBlock FontSize="16" Text="{Binding SettingsCfg.AccountUsername, UpdateSourceTrigger=PropertyChanged}"></TextBlock>
                 <TextBlock FontSize="16">)</TextBlock>
@@ -53,9 +62,14 @@
                 <Button Content="{DynamicResource signout}" x:Name="signout" Click="login2_Click" Margin="0,0,15,0">
                 </Button>
             </StackPanel>
-            
 
-            <TextBlock FontSize="32" FontWeight="SemiBold" Text="{DynamicResource enum_web}"></TextBlock>
+            <Grid Height="50"/>
+            <!-- Big Spacer -->
+
+            <TextBlock FontSize="32" FontWeight="SemiBold" Text="{DynamicResource enum_web}" HorizontalAlignment="Center"></TextBlock>
+            <Grid Height="15"/>
+            <!-- Little Spacer -->
+
             <CheckBox Content="{DynamicResource passmouse}" IsChecked="{Binding SettingsCfg.WebTouchThrough}"></CheckBox>
             <CheckBox Content="{DynamicResource allowjs}" IsChecked="{Binding SettingsCfg.WebScriptEnabled}"></CheckBox>
             <StackPanel Orientation="Horizontal">
@@ -63,12 +77,25 @@
                 <ui:NumberBox ClearButtonEnabled="False" Value="{Binding SettingsCfg.MaxWebFPS, UpdateSourceTrigger=PropertyChanged}" SpinButtonPlacementMode="Hidden"></ui:NumberBox>
             </StackPanel>
 
-            <TextBlock FontSize="32" FontWeight="SemiBold" Text="{DynamicResource graphics}"></TextBlock>
+            <Grid Height="50"/>
+            <!-- Big Spacer -->
+
+            <TextBlock FontSize="32" FontWeight="SemiBold" Text="{DynamicResource graphics}" HorizontalAlignment="Center"></TextBlock>
+            <Grid Height="15"/>
+            <!-- Little Spacer -->
+
             <StackPanel Orientation="Horizontal">
                 <TextBlock VerticalAlignment="Center" Margin="0,0,8,0" Text="{DynamicResource interpquality}"></TextBlock>
                 <ui:NumberBox ClearButtonEnabled="False" Value="{Binding SettingsCfg.InterpolationQuality}" SpinButtonPlacementMode="Hidden"></ui:NumberBox>
             </StackPanel>
-            <TextBlock FontSize="24" FontWeight="SemiBold" Text="{DynamicResource multipletaskbars}"></TextBlock>
+
+            <Grid Height="50"/>
+            <!-- Big Spacer -->
+
+            <TextBlock FontSize="24" FontWeight="SemiBold" Text="{DynamicResource multipletaskbars}" HorizontalAlignment="Center"></TextBlock>
+            <Grid Height="15"/>
+            <!-- Little Spacer -->
+
             <StackPanel Orientation="Horizontal">
                 <CheckBox Content="{DynamicResource graphicsrepeat}" IsChecked="{Binding SettingsCfg.GraphicsRepeat}"></CheckBox>
                 <!--<TextBlock Margin="5,0,0,0" VerticalAlignment="Center" FontSize="10" Text="{DynamicResource perfimpact}">
@@ -88,16 +115,30 @@
             </StackPanel>
             <CheckBox Content="{DynamicResource samerad}" IsChecked="{Binding SettingsCfg.SameRadiusOnEach}"></CheckBox>
 
-            <TextBlock FontSize="32" FontWeight="SemiBold" Text="{DynamicResource globalprop}"></TextBlock>
-            <TextBlock Margin="5,0,0,0" VerticalAlignment="Center" FontSize="10" Text="{DynamicResource globalpropdef}"></TextBlock>
+            <Grid Height="50"/>
+            <!-- Big Spacer -->
+
+            <TextBlock FontSize="32" FontWeight="SemiBold" Text="{DynamicResource globalprop}" HorizontalAlignment="Center"></TextBlock>
+            <Grid Height="15"/>
+            <!-- Little Spacer -->
+
+            <TextBlock VerticalAlignment="Center" FontSize="12" FontWeight="Bold" Text="{DynamicResource globalpropdef}"></TextBlock>
             <StackPanel Orientation="Horizontal">
                 <TextBlock VerticalAlignment="Center" Margin="0,0,8,0" Text="{DynamicResource globalopacity}"></TextBlock>
                 <ui:NumberBox Minimum="-1" Maximum="1" ClearButtonEnabled="False" Value="{Binding SettingsCfg.GlobalOpacity, UpdateSourceTrigger=PropertyChanged}" SpinButtonPlacementMode="Hidden"></ui:NumberBox>
             </StackPanel>
 
+            <Grid Height="50"/>
+            <!-- Big Spacer -->
 
-            <TextBlock FontSize="32" FontWeight="SemiBold">API</TextBlock>
+            <TextBlock FontSize="32" FontWeight="SemiBold" HorizontalAlignment="Center">API</TextBlock>
+            <Grid Height="15"/>
+            <!-- Little Spacer -->
+
             <TextBlock Text="{DynamicResource comingsoon}"></TextBlock>
+            <Grid Height="50"/>
+            <!-- Big Spacer -->
+
         </StackPanel>
     </Grid>
 </Page>


### PR DESCRIPTION
I centered the settings, added spacing between controls, and resized some text blocks. I find that this improves readability, and future settings will be more visible than before.

I left some before-and-after pictures of the edit.
Hope you like it!

**Before**

<img width="2559" height="1390" alt="Capture d'écran 2025-08-05 170125" src="https://github.com/user-attachments/assets/2155ed3d-1fe4-4044-88e9-e9987bc5b779" />
<img width="1049" height="647" alt="Capture d'écran 2025-08-05 170206" src="https://github.com/user-attachments/assets/2c95c36a-cf4e-48c0-a261-4332c4faa4aa" />

**After**

<img width="2559" height="1387" alt="Capture d'écran 2025-08-05 165916" src="https://github.com/user-attachments/assets/8369eaca-a539-4423-83cf-a7cdaff0e791" />
<img width="1069" height="665" alt="Capture d'écran 2025-08-05 165942" src="https://github.com/user-attachments/assets/eba09e7b-b257-4301-bbdc-115f228e0890" />
